### PR TITLE
Correct HYastrophd case

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -5,7 +5,7 @@
 \usepackage{amsmath, amssymb, amsfonts}
 \usepackage{natbib}
 \usepackage{lipsum}
-\usepackage{HYastroPHD}
+\usepackage{HYastrophd}
 
 % Defining these for your included papers will be useful
 \defcitealias{yourcitekey1}{Paper I}


### PR DESCRIPTION
Hi,

I noticed that on some systems your template doesn't compile as is due to case sensitivity problems (looking for the "HYastroPHD" package fails, as the filename is "HYastrophd". This fixes the problem and maybe someone will find it convenient to have. :)

I'm seeing the problem on my Cubbli laptop but not on my Arch Linux desktop so I assume this has something to do with the configuration of one's latex setup. With this commit both my Cubbli and Arch computers work fine.